### PR TITLE
Log message when dropping connection for bad path

### DIFF
--- a/NetfluxWebsocketSrv.js
+++ b/NetfluxWebsocketSrv.js
@@ -288,7 +288,10 @@ module.exports.run = function (
     }, 60000);
     socketServer.on('connection', function(socket, req) {
         if (!socket.upgradeReq) { socket.upgradeReq = req; }
-        if(socket.upgradeReq.url !== (config.websocketPath || '/cryptpad_websocket')) { return; }
+        if(socket.upgradeReq.url !== (config.websocketPath || '/cryptpad_websocket')) {
+            log.silly('NETFLUX_DROPPING_WRONG_PATH', { expectedPath: config.websocketPath, actualPath: socket.upgradeReq.url });
+            return;
+        }
         let conn = socket.upgradeReq.connection;
         let user = {
             addr: conn.remoteAddress + '|' + conn.remotePort,


### PR DESCRIPTION
I hope this can help people in the future when they make a reverse proxy configuration mistake.